### PR TITLE
Add MinGW OpenCL optimizations

### DIFF
--- a/AddrGen/Makefile
+++ b/AddrGen/Makefile
@@ -2,7 +2,7 @@ CPPSRC := $(wildcard *.cpp)
 
 all:
 	$(CXX) -o addrgen$(EXE_EXT) $(CPPSRC) $(INCLUDE) -I$(CUDA_INCLUDE) $(CXXFLAGS) $(LIBS) -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
-       -mkdir $(BINDIR)
+	-mkdir $(BINDIR)
 	cp addrgen$(EXE_EXT) $(BINDIR)/addrgen$(EXE_EXT)
 
 clean:

--- a/AddrGen/Makefile
+++ b/AddrGen/Makefile
@@ -2,7 +2,7 @@ CPPSRC := $(wildcard *.cpp)
 
 all:
 	$(CXX) -o addrgen$(EXE_EXT) $(CPPSRC) $(INCLUDE) -I$(CUDA_INCLUDE) $(CXXFLAGS) $(LIBS) -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
-	mkdir -p $(BINDIR)
+       -mkdir $(BINDIR)
 	cp addrgen$(EXE_EXT) $(BINDIR)/addrgen$(EXE_EXT)
 
 clean:

--- a/AddrGen/Makefile
+++ b/AddrGen/Makefile
@@ -1,10 +1,9 @@
-CPPSRC:=$(wildcard *.cpp)
+CPPSRC := $(wildcard *.cpp)
 
 all:
-    ${CXX} -o addrgen${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
-    mkdir -p $(BINDIR)
-    cp addrgen${EXE_EXT} $(BINDIR)/addrgen${EXE_EXT}
-
+	$(CXX) -o addrgen$(EXE_EXT) $(CPPSRC) $(INCLUDE) -I$(CUDA_INCLUDE) $(CXXFLAGS) $(LIBS) -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
+	mkdir -p $(BINDIR)
+	cp addrgen$(EXE_EXT) $(BINDIR)/addrgen$(EXE_EXT)
 
 clean:
-    rm -rf addrgen${EXE_EXT}
+	rm -rf addrgen$(EXE_EXT)

--- a/AddrGen/Makefile
+++ b/AddrGen/Makefile
@@ -1,10 +1,10 @@
 CPPSRC:=$(wildcard *.cpp)
 
 all:
-	${CXX} -o addrgen.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
-	mkdir -p $(BINDIR)
-	cp addrgen.bin $(BINDIR)/addrgen
+    ${CXX} -o addrgen${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
+    mkdir -p $(BINDIR)
+    cp addrgen${EXE_EXT} $(BINDIR)/addrgen${EXE_EXT}
 
 
 clean:
-	rm -rf addrgen.bin
+    rm -rf addrgen${EXE_EXT}

--- a/AddressUtil/Makefile
+++ b/AddressUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/AddressUtil/Makefile
+++ b/AddressUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/AddressUtil/Makefile
+++ b/AddressUtil/Makefile
@@ -1,12 +1,15 @@
-NAME=addressutil
-SRC=$(wildcard *.cpp)
+NAME = addressutil
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} ${CXXFLAGS};\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a *.o
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.o

--- a/CLKeySearchDevice/Makefile
+++ b/CLKeySearchDevice/Makefile
@@ -1,15 +1,19 @@
-NAME=CLKeySearchDevice
-CPPSRC:=$(wildcard *.cpp)
+NAME = CLKeySearchDevice
+CPPSRC := $(wildcard *.cpp)
+OBJS := $(CPPSRC:.cpp=.o) bitcrack_cl.o
 
-all:
-	cat ../clMath/sha256.cl ../clMath/secp256k1.cl ../clMath/ripemd160.cl keysearch.cl > bitcrack.cl
-	${BINDIR}/embedcl bitcrack.cl bitcrack_cl.cpp _bitcrack_cl
+all: $(LIBDIR)/lib$(NAME).a
 
-	for file in ${CPPSRC} bitcrack_cl.cpp; do\
-		${CXX} -c $$file ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS};\
-	done
+bitcrack_cl.cpp: ../clMath/sha256.cl ../clMath/secp256k1.cl ../clMath/ripemd160.cl keysearch.cl
+	cat $^ > bitcrack.cl
+	$(BINDIR)/embedcl bitcrack.cl $@ _bitcrack_cl
 
-	ar rvs ${LIBDIR}/lib$(NAME).a *.o
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) -I$(OPENCL_INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.a *.o bitcrack.cl bitcrack_cl.cpp

--- a/CLKeySearchDevice/Makefile
+++ b/CLKeySearchDevice/Makefile
@@ -16,4 +16,4 @@ $(LIBDIR)/lib$(NAME).a: $(OBJS)
 	$(CXX) -c $< $(INCLUDE) -I$(OPENCL_INCLUDE) $(CXXFLAGS)
 
 clean:
-	rm -rf *.a *.o bitcrack.cl bitcrack_cl.cpp
+       rm -rf *.a *.o bitcrack_cl.cpp

--- a/CLKeySearchDevice/Makefile
+++ b/CLKeySearchDevice/Makefile
@@ -9,7 +9,7 @@ bitcrack_cl.cpp: ../clMath/sha256.cl ../clMath/secp256k1.cl ../clMath/ripemd160.
 	$(BINDIR)/embedcl bitcrack.cl $@ _bitcrack_cl
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/CLKeySearchDevice/Makefile
+++ b/CLKeySearchDevice/Makefile
@@ -9,7 +9,7 @@ bitcrack_cl.cpp: ../clMath/sha256.cl ../clMath/secp256k1.cl ../clMath/ripemd160.
 	$(BINDIR)/embedcl bitcrack.cl $@ _bitcrack_cl
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -6,7 +6,7 @@ $(BINDIR)/clunittest$(EXE_EXT): main.cpp secp256k1test.cl
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
 	$(BINDIR)/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
 	$(CXX) -o clunittest$(EXE_EXT) main.cpp cltest.cpp $(INCLUDE) -I$(OPENCL_INCLUDE) $(CXXFLAGS) $(LIBS) -L$(OPENCL_LIB) -lclutil -lutil -lOpenCL
-       -mkdir $(BINDIR)
+	-mkdir $(BINDIR)
 	cp clunittest$(EXE_EXT) $@
 
 clean:

--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -1,16 +1,13 @@
-NAME=CLUnitTests
-CPPSRC:=$(wildcard *.cpp)
+NAME = CLUnitTests
 
-all:
+all: $(BINDIR)/clunittest$(EXE_EXT)
+
+$(BINDIR)/clunittest$(EXE_EXT): main.cpp secp256k1test.cl
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
-	${BINDIR}/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
-
-	    ${CXX} -o clunittest${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
-		mkdir -p $(BINDIR)
-
-	    cp clunittest${EXE_EXT} $(BINDIR)/clunittest${EXE_EXT}
-
-
+	$(BINDIR)/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
+	$(CXX) -o clunittest$(EXE_EXT) main.cpp cltest.cpp $(INCLUDE) -I$(OPENCL_INCLUDE) $(CXXFLAGS) $(LIBS) -L$(OPENCL_LIB) -lclutil -lutil -lOpenCL
+	mkdir -p $(BINDIR)
+	cp clunittest$(EXE_EXT) $@
 
 clean:
-	    rm -rf *.a *.o clunittest${EXE_EXT} cltest.cl cltest.cpp
+	rm -rf *.a *.o clunittest$(EXE_EXT) cltest.cl cltest.cpp

--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -5,12 +5,12 @@ all:
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
 	${BINDIR}/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
 
-	${CXX} -o clunittest.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
-	mkdir -p $(BINDIR)
+	    ${CXX} -o clunittest${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lclutil -lutil -lOpenCL
+		mkdir -p $(BINDIR)
 
-	cp clunittest.bin $(BINDIR)/clunittest
+	    cp clunittest${EXE_EXT} $(BINDIR)/clunittest${EXE_EXT}
 
 
 
 clean:
-	rm -rf *.a *.o clunittest.bin cltest.cl cltest.cpp
+	    rm -rf *.a *.o clunittest${EXE_EXT} cltest.cl cltest.cpp

--- a/CLUnitTests/Makefile
+++ b/CLUnitTests/Makefile
@@ -6,7 +6,7 @@ $(BINDIR)/clunittest$(EXE_EXT): main.cpp secp256k1test.cl
 	cat ../clMath/secp256k1.cl secp256k1test.cl > cltest.cl
 	$(BINDIR)/embedcl cltest.cl cltest.cpp _secp256k1_test_cl
 	$(CXX) -o clunittest$(EXE_EXT) main.cpp cltest.cpp $(INCLUDE) -I$(OPENCL_INCLUDE) $(CXXFLAGS) $(LIBS) -L$(OPENCL_LIB) -lclutil -lutil -lOpenCL
-	mkdir -p $(BINDIR)
+       -mkdir $(BINDIR)
 	cp clunittest$(EXE_EXT) $@
 
 clean:

--- a/CmdParse/Makefile
+++ b/CmdParse/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/CmdParse/Makefile
+++ b/CmdParse/Makefile
@@ -1,13 +1,15 @@
-NAME=cmdparse
-SRC=$(wildcard *.cpp)
-OBJS=$(SRC:.cpp=.o)
+NAME = cmdparse
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} ${CXXFLAGS};\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a ${OBJS}
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.o

--- a/CmdParse/Makefile
+++ b/CmdParse/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/CryptoUtil/Makefile
+++ b/CryptoUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/CryptoUtil/Makefile
+++ b/CryptoUtil/Makefile
@@ -1,12 +1,15 @@
-NAME=cryptoutil
-SRC=$(wildcard *.cpp)
+NAME = cryptoutil
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} ${CXXFLAGS};\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a *.o
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.o

--- a/CryptoUtil/Makefile
+++ b/CryptoUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/CryptoUtil/Rng.cpp
+++ b/CryptoUtil/Rng.cpp
@@ -4,7 +4,7 @@
 #include "CryptoUtil.h"
 
 #ifdef _WIN32
-#include<Windows.h>
+#include <windows.h>
 #include <bcrypt.h>
 
 static void secureRandom(unsigned char *buf, unsigned int count)

--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -1,22 +1,24 @@
-NAME=CudaKeySearchDevice
-CPPSRC:=$(wildcard *.cpp)
-CUSRC:=$(wildcard *.cu)
+NAME = CudaKeySearchDevice
+CPPSRC := $(wildcard *.cpp)
+CUSRC := $(wildcard *.cu)
+CPP_OBJS := $(CPPSRC:.cpp=.o)
+CU_OBJS := $(CUSRC:.cu=.cu.o)
 
-all:	cuda
+all: $(LIBDIR)/lib$(NAME).a
 
-cuda:
-	for file in ${CPPSRC} ; do\
-		${CXX} -c $$file ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS};\
-	done
+$(LIBDIR)/lib$(NAME).a: $(CPP_OBJS) $(CU_OBJS) cuda_libs.o
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
 
-	for file in ${CUSRC} ; do\
-		${NVCC} -c $$file -o $$file".o" ${NVCCFLAGS} -rdc=true ${INCLUDE} -I${CUDA_INCLUDE} -I${CUDA_MATH};\
-	done
+cuda_libs.o: $(CU_OBJS)
+	$(NVCC) -dlink -o $@ $^ -lcudadevrt -lcudart
 
-	${NVCC} -dlink -o cuda_libs.o *.cu.o -lcudadevrt -lcudart
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) -I$(CUDA_INCLUDE) $(CXXFLAGS)
 
-	ar rvs ${LIBDIR}/lib$(NAME).a *.o
+%.cu.o: %.cu
+	$(NVCC) -c $< -o $@ $(NVCCFLAGS) -rdc=true $(INCLUDE) -I$(CUDA_INCLUDE) -I$(CUDA_MATH)
 
 clean:
-	rm -f *.o *.cu.o
+	rm -f *.o *.cu.o cuda_libs.o
 	rm -f *.a

--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -7,7 +7,7 @@ CU_OBJS := $(CUSRC:.cu=.cu.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(CPP_OBJS) $(CU_OBJS) cuda_libs.o
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 cuda_libs.o: $(CU_OBJS)

--- a/CudaKeySearchDevice/Makefile
+++ b/CudaKeySearchDevice/Makefile
@@ -7,7 +7,7 @@ CU_OBJS := $(CUSRC:.cu=.cu.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(CPP_OBJS) $(CU_OBJS) cuda_libs.o
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 cuda_libs.o: $(CU_OBJS)

--- a/KeyFinder/DeviceManager.cpp
+++ b/KeyFinder/DeviceManager.cpp
@@ -27,6 +27,7 @@ std::vector<DeviceManager::DeviceInfo> DeviceManager::getDevices()
             device.physicalId = cudaDevices[i].id;
             device.memory = cudaDevices[i].mem;
             device.computeUnits = cudaDevices[i].mpCount;
+            device.maxThreadsPerBlock = cudaDevices[i].maxThreadsPerBlock;
             devices.push_back(device);
 
             deviceId++;
@@ -49,6 +50,7 @@ std::vector<DeviceManager::DeviceInfo> DeviceManager::getDevices()
             device.physicalId = (uint64_t)clDevices[i].id;
             device.memory = clDevices[i].mem;
             device.computeUnits = clDevices[i].cores;
+            device.maxThreadsPerBlock = (int)clDevices[i].maxWorkGroupSize;
             devices.push_back(device);
             deviceId++;
         }

--- a/KeyFinder/DeviceManager.h
+++ b/KeyFinder/DeviceManager.h
@@ -36,6 +36,7 @@ typedef struct {
     std::string name;
     uint64_t memory;
     int computeUnits;
+    int maxThreadsPerBlock;
 
     // CUDA device info
     int cudaMajor;

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -3,12 +3,12 @@ CPPSRC:=$(wildcard *.cpp)
 all:
 ifeq ($(BUILD_CUDA), 1)
 	${CXX} -DBUILD_CUDA -o cuKeyFinder${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
-	mkdir -p $(BINDIR)
+-mkdir $(BINDIR)
 	cp cuKeyFinder${EXE_EXT} $(BINDIR)/cuBitCrack${EXE_EXT}
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
-	mkdir -p $(BINDIR)
+-mkdir $(BINDIR)
 	cp clKeyFinder${EXE_EXT} $(BINDIR)/clBitCrack${EXE_EXT}
 endif
 

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -3,12 +3,12 @@ CPPSRC:=$(wildcard *.cpp)
 all:
 ifeq ($(BUILD_CUDA), 1)
 	${CXX} -DBUILD_CUDA -o cuKeyFinder${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
--mkdir $(BINDIR)
+	-mkdir $(BINDIR)
 	cp cuKeyFinder${EXE_EXT} $(BINDIR)/cuBitCrack${EXE_EXT}
 endif
 ifeq ($(BUILD_OPENCL),1)
 	${CXX} -DBUILD_OPENCL -o clKeyFinder${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
--mkdir $(BINDIR)
+	-mkdir $(BINDIR)
 	cp clKeyFinder${EXE_EXT} $(BINDIR)/clBitCrack${EXE_EXT}
 endif
 

--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -2,16 +2,16 @@ CPPSRC:=$(wildcard *.cpp)
 
 all:
 ifeq ($(BUILD_CUDA), 1)
-	${CXX} -DBUILD_CUDA -o cuKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
+	${CXX} -DBUILD_CUDA -o cuKeyFinder${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lcudautil -llogger -lutil -lCudaKeySearchDevice -lcudadevrt -lcudart -lcmdparse
 	mkdir -p $(BINDIR)
-	cp cuKeyFinder.bin $(BINDIR)/cuBitCrack
+	cp cuKeyFinder${EXE_EXT} $(BINDIR)/cuBitCrack${EXE_EXT}
 endif
 ifeq ($(BUILD_OPENCL),1)
-	${CXX} -DBUILD_OPENCL -o clKeyFinder.bin ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
+	${CXX} -DBUILD_OPENCL -o clKeyFinder${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS} ${LIBS} -L${OPENCL_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lCLKeySearchDevice -lclutil -lOpenCL -llogger -lutil -lcmdparse
 	mkdir -p $(BINDIR)
-	cp clKeyFinder.bin $(BINDIR)/clBitCrack
+	cp clKeyFinder${EXE_EXT} $(BINDIR)/clBitCrack${EXE_EXT}
 endif
 
 clean:
-	rm -rf cuKeyFinder.bin
-	rm -rf clKeyFinder.bin
+	rm -rf cuKeyFinder${EXE_EXT}
+	rm -rf clKeyFinder${EXE_EXT}

--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -229,12 +229,16 @@ typedef struct {
 
 DeviceParameters getDefaultParameters(const DeviceManager::DeviceInfo &device)
 {
-	DeviceParameters p;
-	p.threads = 256;
-    p.blocks = 32;
-	p.pointsPerThread = 32;
+    DeviceParameters p;
+    p.pointsPerThread = 32;
 
-	return p;
+    // Use as many compute units as available
+    p.blocks = device.computeUnits;
+
+    // Use device's max supported threads per block
+    p.threads = device.maxThreadsPerBlock;
+
+    return p;
 }
 
 static KeySearchDevice *getDeviceContext(DeviceManager::DeviceInfo &device, int blocks, int threads, int pointsPerThread)
@@ -261,6 +265,7 @@ static void printDeviceList(const std::vector<DeviceManager::DeviceInfo> &device
         printf("Name:   %s\n", devices[i].name.c_str());
         printf("Memory: %lldMB\n", devices[i].memory / ((uint64_t)1024 * 1024));
         printf("Compute units: %d\n", devices[i].computeUnits);
+        printf("Max threads per block: %d\n", devices[i].maxThreadsPerBlock);
         printf("\n");
     }
 }

--- a/KeyFinderLib/Makefile
+++ b/KeyFinderLib/Makefile
@@ -1,14 +1,15 @@
-NAME=keyfinder
-CPPSRC:=$(wildcard *.cpp)
+NAME = keyfinder
+CPPSRC := $(wildcard *.cpp)
+OBJS := $(CPPSRC:.cpp=.o)
 
-all:	cuda
+all: $(LIBDIR)/lib$(NAME).a
 
-cuda:
-	for file in ${CPPSRC} ; do\
-		${CXX} -c $$file ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS};\
-	done
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
 
-	ar rvs ${LIBDIR}/lib$(NAME).a *.o
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) -I$(CUDA_INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -f *.o *.cu.o

--- a/KeyFinderLib/Makefile
+++ b/KeyFinderLib/Makefile
@@ -5,7 +5,7 @@ OBJS := $(CPPSRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/KeyFinderLib/Makefile
+++ b/KeyFinderLib/Makefile
@@ -5,7 +5,7 @@ OBJS := $(CPPSRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/Logger/Makefile
+++ b/Logger/Makefile
@@ -1,13 +1,15 @@
-NAME=logger
-SRC=$(wildcard *.cpp)
-OBJS=$(SRC:.cpp=.o)
+NAME = logger
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} ${CXXFLAGS};\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a ${OBJS}
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.o

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,19 @@ LIBS+=-L$(LIBDIR)
 # C++ options
 EXE_EXT ?=
 CXX=g++
-CXXFLAGS=-O2 -std=c++11
-BUILD_OPENCL ?= 1
-BUILD_CUDA ?= 0
-
+CXXFLAGS=-O3 -std=c++11
 ifeq ($(MINGW),1)
 EXE_EXT=.exe
 CXX=x86_64-w64-mingw32-g++
 NVCC=nvcc -ccbin $(CXX)
 CXXFLAGS+=-static
 LIBS+=-static-libstdc++ -static-libgcc
+else
+CXXFLAGS+=-march=native
 endif
+BUILD_OPENCL ?= 1
+BUILD_CUDA ?= 0
+
 
 # CUDA variables
 COMPUTE_CAP=30

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-CUR_DIR=$(shell pwd)
+CUR_DIR:=$(CURDIR)
 DIRS=util AddressUtil CmdParse CryptoUtil KeyFinderLib CLKeySearchDevice CudaKeySearchDevice cudaMath clUtil cudaUtil secp256k1lib Logger embedcl
 
 INCLUDE = $(foreach d, $(DIRS), -I$(CUR_DIR)/$d)

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,19 @@ BINDIR=$(CUR_DIR)/bin
 LIBS+=-L$(LIBDIR)
 
 # C++ options
+EXE_EXT ?=
 CXX=g++
 CXXFLAGS=-O2 -std=c++11
+BUILD_OPENCL ?= 1
+BUILD_CUDA ?= 0
+
+ifeq ($(MINGW),1)
+EXE_EXT=.exe
+CXX=x86_64-w64-mingw32-g++
+NVCC=nvcc -ccbin $(CXX)
+CXXFLAGS+=-static
+LIBS+=-static-libstdc++ -static-libgcc
+endif
 
 # CUDA variables
 COMPUTE_CAP=30
@@ -34,6 +45,7 @@ export NVCCFLAGS
 export LIBS
 export CXX
 export CXXFLAGS
+export EXE_EXT
 export CUDA_LIB
 export CUDA_INCLUDE
 export CUDA_MATH

--- a/Makefile
+++ b/Makefile
@@ -70,25 +70,25 @@ endif
 all:	${TARGETS}
 
 dir_cudaKeySearchDevice: dir_keyfinderlib dir_cudautil dir_logger
-	make --directory CudaKeySearchDevice
+	mingw32-make --directory CudaKeySearchDevice
 
 dir_clKeySearchDevice: dir_embedcl dir_keyfinderlib dir_clutil dir_logger
-	make --directory CLKeySearchDevice
+	mingw32-make --directory CLKeySearchDevice
 
 dir_embedcl:
-	make --directory embedcl
+	mingw32-make --directory embedcl
 
 dir_addressutil:	dir_util dir_secp256k1lib dir_cryptoutil
-	make --directory AddressUtil
+	mingw32-make --directory AddressUtil
 
 dir_cmdparse:
-	make --directory CmdParse
+	mingw32-make --directory CmdParse
 
 dir_cryptoutil:
-	make --directory CryptoUtil
+	mingw32-make --directory CryptoUtil
 
 dir_keyfinderlib:	dir_util dir_secp256k1lib dir_cryptoutil dir_addressutil dir_logger
-	make --directory KeyFinderLib
+	mingw32-make --directory KeyFinderLib
 
 KEYFINDER_DEPS=dir_keyfinderlib
 
@@ -101,46 +101,46 @@ ifeq ($(BUILD_OPENCL),1)
 endif
 
 dir_keyfinder:	$(KEYFINDER_DEPS)
-	make --directory KeyFinder
+	mingw32-make --directory KeyFinder
 
 dir_cudautil:
-	make --directory cudaUtil
+	mingw32-make --directory cudaUtil
 
 dir_clutil:
-	make --directory clUtil
+	mingw32-make --directory clUtil
 
 dir_secp256k1lib:	dir_cryptoutil
-	make --directory secp256k1lib
+	mingw32-make --directory secp256k1lib
 
 dir_util:
-	make --directory util
+	mingw32-make --directory util
 
 dir_cudainfo:
-	make --directory cudaInfo
+	mingw32-make --directory cudaInfo
 
 dir_logger:
-	make --directory Logger
+	mingw32-make --directory Logger
 
 dir_addrgen:	dir_cmdparse dir_addressutil dir_secp256k1lib
-	make --directory AddrGen
+	mingw32-make --directory AddrGen
 dir_clunittest:	dir_clutil
-	make --directory CLUnitTests
+	mingw32-make --directory CLUnitTests
 
 clean:
-	make --directory AddressUtil clean
-	make --directory CmdParse clean
-	make --directory CryptoUtil clean
-	make --directory KeyFinderLib clean
-	make --directory KeyFinder clean
-	make --directory cudaUtil clean
-	make --directory secp256k1lib clean
-	make --directory util clean
-	make --directory cudaInfo clean
-	make --directory Logger clean
-	make --directory clUtil clean
-	make --directory CLKeySearchDevice clean
-	make --directory CudaKeySearchDevice clean
-	make --directory embedcl clean
-	make --directory CLUnitTests clean
+	mingw32-make --directory AddressUtil clean
+	mingw32-make --directory CmdParse clean
+	mingw32-make --directory CryptoUtil clean
+	mingw32-make --directory KeyFinderLib clean
+	mingw32-make --directory KeyFinder clean
+	mingw32-make --directory cudaUtil clean
+	mingw32-make --directory secp256k1lib clean
+	mingw32-make --directory util clean
+	mingw32-make --directory cudaInfo clean
+	mingw32-make --directory Logger clean
+	mingw32-make --directory clUtil clean
+	mingw32-make --directory CLKeySearchDevice clean
+	mingw32-make --directory CudaKeySearchDevice clean
+	mingw32-make --directory embedcl clean
+	mingw32-make --directory CLUnitTests clean
 	rm -rf ${LIBDIR}
 	rm -rf ${BINDIR}

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Build the `clKeyFinder` project for an OpenCL build.
 
 Build the `cuKeyFinder` project for a CUDA build.
 
+If you prefer a command line build on Windows, install MinGW and run `mingw32-make` from a shell. Each library directory like `util`, `AddressUtil`, and `KeyFinderLib` contains its own Makefile. Generated folders such as `.vs`, `Debug`, `Release` and `x64` do not require Makefiles.
+
 Note: By default the NVIDIA OpenCL headers are used. You can set the header and library path for
 OpenCL in the `BitCrack.props` property sheet.
 

--- a/clUtil/Makefile
+++ b/clUtil/Makefile
@@ -1,13 +1,15 @@
-NAME=clutil
-SRC=$(wildcard *.cpp)
-OBJS=$(SRC:.cpp=.o)
+NAME = clutil
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} -I${OPENCL_INCLUDE} ${CXXFLAGS};\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a ${OBJS}
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) -I$(OPENCL_INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.o

--- a/clUtil/Makefile
+++ b/clUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/clUtil/Makefile
+++ b/clUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/clUtil/clUtil.cpp
+++ b/clUtil/clUtil.cpp
@@ -52,6 +52,10 @@ std::vector<cl::CLDeviceInfo> cl::getDevices()
 
             info.cores = cores;
 
+            size_t maxWG = 0;
+            clCall(clGetDeviceInfo(devices[j], CL_DEVICE_MAX_WORK_GROUP_SIZE, sizeof(maxWG), &maxWG, NULL));
+            info.maxWorkGroupSize = maxWG;
+
             cl_ulong mem;
             clCall(clGetDeviceInfo(devices[j], CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(mem), &mem, NULL));
 

--- a/clUtil/clutil.h
+++ b/clUtil/clutil.h
@@ -18,6 +18,7 @@ namespace cl {
         cl_device_id id;
         int cores;
         uint64_t mem;
+        size_t maxWorkGroupSize;
         std::string name;
 
     }CLDeviceInfo;

--- a/cudaInfo/Makefile
+++ b/cudaInfo/Makefile
@@ -2,7 +2,7 @@ CPPSRC:=$(wildcard *.cpp)
 
 all:
 	    ${CXX} -o cudainfo${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lcudautil -lcudart
-	    mkdir -p $(BINDIR)
+       -mkdir $(BINDIR)
 	    cp cudainfo${EXE_EXT} $(BINDIR)/cudainfo${EXE_EXT}
 
 clean:

--- a/cudaInfo/Makefile
+++ b/cudaInfo/Makefile
@@ -2,7 +2,7 @@ CPPSRC:=$(wildcard *.cpp)
 
 all:
 	    ${CXX} -o cudainfo${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lcudautil -lcudart
-       -mkdir $(BINDIR)
+	-mkdir $(BINDIR)
 	    cp cudainfo${EXE_EXT} $(BINDIR)/cudainfo${EXE_EXT}
 
 clean:

--- a/cudaInfo/Makefile
+++ b/cudaInfo/Makefile
@@ -1,9 +1,9 @@
 CPPSRC:=$(wildcard *.cpp)
 
 all:
-	${CXX} -o cudainfo.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lcudautil -lcudart 
-	mkdir -p $(BINDIR)
-	cp cudainfo.bin $(BINDIR)/cudainfo
+	    ${CXX} -o cudainfo${EXE_EXT} ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -L${CUDA_LIB} -lcudautil -lcudart
+	    mkdir -p $(BINDIR)
+	    cp cudainfo${EXE_EXT} $(BINDIR)/cudainfo${EXE_EXT}
 
 clean:
-	rm -rf cudainfo.bin
+	rm -rf cudainfo${EXE_EXT}

--- a/cudaUtil/Makefile
+++ b/cudaUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/cudaUtil/Makefile
+++ b/cudaUtil/Makefile
@@ -1,13 +1,15 @@
-NAME=cudautil
-SRC=$(wildcard *.cpp)
-OBJS=$(SRC:.cpp=.o)
+NAME = cudautil
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS};\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a ${OBJS}
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) -I$(CUDA_INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.o

--- a/cudaUtil/Makefile
+++ b/cudaUtil/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/cudaUtil/cudaUtil.cpp
+++ b/cudaUtil/cudaUtil.cpp
@@ -23,9 +23,10 @@ cuda::CudaDeviceInfo cuda::getDeviceInfo(int device)
 	devInfo.id = device;
 	devInfo.major = properties.major;
 	devInfo.minor = properties.minor;
-	devInfo.mpCount = properties.multiProcessorCount;
-	devInfo.mem = properties.totalGlobalMem;
-	devInfo.name = std::string(properties.name);
+        devInfo.mpCount = properties.multiProcessorCount;
+        devInfo.maxThreadsPerBlock = properties.maxThreadsPerBlock;
+        devInfo.mem = properties.totalGlobalMem;
+        devInfo.name = std::string(properties.name);
 
 	int cores = 0;
 	switch(devInfo.major) {

--- a/cudaUtil/cudaUtil.h
+++ b/cudaUtil/cudaUtil.h
@@ -13,10 +13,11 @@ namespace cuda {
 		int id;
 		int major;
 		int minor;
-		int mpCount;
-		int cores;
-		uint64_t mem;
-		std::string name;
+                int mpCount;
+                int cores;
+                int maxThreadsPerBlock;
+                uint64_t mem;
+                std::string name;
 
 	}CudaDeviceInfo;
 

--- a/embedcl/Makefile
+++ b/embedcl/Makefile
@@ -3,7 +3,7 @@ NAME = embedcl
 
 all:
 	$(CXX) -o $(NAME)$(EXE_EXT) $(CPPSRC) $(INCLUDE) $(CXXFLAGS)
-       -mkdir $(BINDIR)
+	-mkdir $(BINDIR)
 	cp $(NAME)$(EXE_EXT) $(BINDIR)/$(NAME)$(EXE_EXT)
 
 clean:

--- a/embedcl/Makefile
+++ b/embedcl/Makefile
@@ -1,10 +1,10 @@
-CPPSRC:=$(wildcard *.cpp)
-NAME=embedcl
+CPPSRC := $(wildcard *.cpp)
+NAME = embedcl
 
 all:
-	${CXX} -o ${NAME} ${CPPSRC} ${INCLUDE} ${CXXFLAGS}
+	$(CXX) -o $(NAME)$(EXE_EXT) $(CPPSRC) $(INCLUDE) $(CXXFLAGS)
 	mkdir -p $(BINDIR)
-	cp ${NAME} $(BINDIR)/${NAME}
+	cp $(NAME)$(EXE_EXT) $(BINDIR)/$(NAME)$(EXE_EXT)
 
 clean:
-	rm -rf ${NAME}
+	rm -rf $(NAME)$(EXE_EXT)

--- a/embedcl/Makefile
+++ b/embedcl/Makefile
@@ -3,7 +3,7 @@ NAME = embedcl
 
 all:
 	$(CXX) -o $(NAME)$(EXE_EXT) $(CPPSRC) $(INCLUDE) $(CXXFLAGS)
-	mkdir -p $(BINDIR)
+       -mkdir $(BINDIR)
 	cp $(NAME)$(EXE_EXT) $(BINDIR)/$(NAME)$(EXE_EXT)
 
 clean:

--- a/secp256k1lib/Makefile
+++ b/secp256k1lib/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/secp256k1lib/Makefile
+++ b/secp256k1lib/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/secp256k1lib/Makefile
+++ b/secp256k1lib/Makefile
@@ -1,13 +1,15 @@
-NAME=secp256k1
-SRC=$(wildcard *.cpp)
-OBJS=$(SRC:.cpp=.o)
+NAME = secp256k1
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} ${CXXFLAGS} ${LIBS} -lcryptoutil;\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a ${OBJS}
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) $(CXXFLAGS) $(LIBS) -lcryptoutil
 
 clean:
 	rm -rf *.o

--- a/util/Makefile
+++ b/util/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-       -mkdir $(LIBDIR)
+	-mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/util/Makefile
+++ b/util/Makefile
@@ -5,7 +5,7 @@ OBJS := $(SRC:.cpp=.o)
 all: $(LIBDIR)/lib$(NAME).a
 
 $(LIBDIR)/lib$(NAME).a: $(OBJS)
-	mkdir -p $(LIBDIR)
+       -mkdir $(LIBDIR)
 	ar rvs $@ $^
 
 %.o: %.cpp

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,13 +1,15 @@
-NAME=util
-SRC=$(wildcard *.cpp)
-OBJS=$(SRC:.cpp=.o)
+NAME = util
+SRC  := $(wildcard *.cpp)
+OBJS := $(SRC:.cpp=.o)
 
-all:    ${SRC}
-	for file in ${SRC} ; do\
-		${CXX} -c $$file ${INCLUDE} ${CXXFLAGS};\
-	done
-	mkdir -p ${LIBDIR}
-	ar rvs ${LIBDIR}/lib$(NAME).a ${OBJS}
+all: $(LIBDIR)/lib$(NAME).a
+
+$(LIBDIR)/lib$(NAME).a: $(OBJS)
+	mkdir -p $(LIBDIR)
+	ar rvs $@ $^
+
+%.o: %.cpp
+	$(CXX) -c $< $(INCLUDE) $(CXXFLAGS)
 
 clean:
 	rm -rf *.o


### PR DESCRIPTION
## Summary
- enable default OpenCL build for MinGW
- report each device's max thread capability and use it for defaults
- fix KeyFinder Windows Makefile rules

## Testing
- `make clean`
- `make BUILD_OPENCL=1 BUILD_CUDA=1` *(fails: CL/cl.h and cuda.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687413e359088322b1a970edb60bccfb